### PR TITLE
Depend on Rust 2021 edition at least

### DIFF
--- a/topiary.opam
+++ b/topiary.opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/tweag/topiary/issues"
 dev-repo: "git+https://github.com/tweag/topiary.git"
 
 license: "MIT"
-depends: ["conf-rust"]
+depends: ["conf-rust-2021"]
 
 build:[
   [ "cargo" "build" "--release" "--package" "topiary" ]


### PR DESCRIPTION
This does not fix everything because we still depend on a very recent version of Rust anyways, but this is already a step towards specifying our dependencies better.