### PR TITLE
Remove `expected-failure` for Alpine and Archlinux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,8 +129,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {tag: alpine,          ef: expected-failure}
-          - {tag: archlinux,       ef: expected-failure}
+          - {tag: alpine}
+          - {tag: archlinux}
           - {tag: centos,          ef: expected-failure}
           - {tag: debian,          ef: expected-failure}
           - {tag: debian-testing,  ef: expected-failure}


### PR DESCRIPTION
[This night's CI run](https://github.com/tweag/topiary-opam/actions/runs/4975148943) suggests that the `ocaml/opam` Docker images have been updated and that (a) Alpine now ships with a recent enough version of Rust and (b) Archlinux fixed their dead repository issue. This PR removes the `expected-failure` flag for these two distributions.