### PR TITLE
Improve the Topiary CLI wrapper

### DIFF
--- a/make-topiary-wrapper.sh
+++ b/make-topiary-wrapper.sh
@@ -64,7 +64,10 @@ cat > "$output_file" <<EOF
 #!/bin/sh
 set -euC
 
-export TOPIARY_LANGUAGE_DIR=$language_dir
+## If \$TOPIARY_LANGUAGE_DIR is set, then keep it (even if it is null). If it is
+## unset, default to $language_dir.
+export TOPIARY_LANGUAGE_DIR=\${TOPIARY_LANGUAGE_DIR-$language_dir}
+
 exec $topiary_wrapped "\$@"
 EOF
 

--- a/topiary.opam
+++ b/topiary.opam
@@ -16,12 +16,13 @@ build:[
       "--package" "topiary-cli" ]
   [ "sh" "make-topiary-wrapper.sh"
       "--language-dir" "%{share}%/topiary/languages"
-      "--topiary-wrapped" "%{bin}%/.topiary-wrapped"
+      "--topiary-wrapped" "%{bin}%/.topiary-wrapped/topiary"
       "--output-file" "topiary-wrapper" ]
 ]
 
 install: [
-  [ "cp" "target/release/topiary" "%{bin}%/.topiary-wrapped" ]
+  [ "mkdir" "%{bin}%/.topiary-wrapped" ]
+  [ "cp" "target/release/topiary" "%{bin}%/.topiary-wrapped/topiary" ]
   [ "cp" "topiary-wrapper" "%{bin}%/topiary" ]
   [ "mkdir" "%{share}%/topiary" ]
   [ "cp" "-R" "topiary/languages" "%{share}%/topiary/languages" ]


### PR DESCRIPTION
We bring two improvements:

First, the topiary wrapper now recognizes when `TOPIARY_LANGUAGE_DIR` is set and uses it in that case. This is true even if it is set to null (eg. with `TOPIARY_LANGUAGE_DIR= topiary ...`). Otherwise, we default to a directory in the OPAM switch that contains the query files shipped with Topiary.

Second, we move the actual binary of Topiary that was previously put in `%{bin}%/.topiary-wrapped` into `%{bin}%/.topiary-wrapped/topiary`. This changes very little but ensures that `topiary --help` shows `topiary` as a command name and not `.topiary-wrapped` like before.